### PR TITLE
fixup: get container pid from state file for external container network setup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -989,7 +989,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	}
 
 	sysInfo := sysinfo.New(false)
-	ed, err := execdrivers.NewDriver(config.ExecDriver, config.Root, sysInitPath, sysInfo)
+	ed, err := execdrivers.NewDriver(config.ExecDriver, config.Root, sysInitPath, execdriver.NativeBuiltin, sysInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -20,6 +20,11 @@ var (
 	ErrDriverNotFound          = errors.New("The requested docker init has not been found")
 )
 
+const (
+	NativeBuiltin  = "builtin"
+	NativeExternal = "external"
+)
+
 type StartCallback func(*ProcessConfig, int)
 
 // Driver specific information based on

--- a/daemon/execdriver/execdrivers/execdrivers.go
+++ b/daemon/execdriver/execdrivers/execdrivers.go
@@ -9,7 +9,7 @@ import (
 	"path"
 )
 
-func NewDriver(name, root, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
+func NewDriver(name, root, initPath, extra string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
 	switch name {
 	case "lxc":
 		// we want to give the lxc driver the full docker root because it needs
@@ -17,7 +17,7 @@ func NewDriver(name, root, initPath string, sysInfo *sysinfo.SysInfo) (execdrive
 		// to be backwards compatible
 		return lxc.NewDriver(root, initPath, sysInfo.AppArmor)
 	case "native":
-		return native.NewDriver(path.Join(root, "execdriver", "native"), initPath)
+		return native.NewDriver(path.Join(root, "execdriver", "native"), initPath, extra)
 	}
 	return nil, fmt.Errorf("unknown exec driver %s", name)
 }

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -41,10 +41,13 @@ type driver struct {
 	root             string
 	initPath         string
 	activeContainers map[string]*activeContainer
+
+	//driverType builtin or external
+	driverType string
 	sync.Mutex
 }
 
-func NewDriver(root, initPath string) (*driver, error) {
+func NewDriver(root, initPath, driverType string) (*driver, error) {
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
@@ -58,6 +61,7 @@ func NewDriver(root, initPath string) (*driver, error) {
 		root:             root,
 		initPath:         initPath,
 		activeContainers: make(map[string]*activeContainer),
+		driverType:       driverType,
 	}, nil
 }
 

--- a/daemon/monitor_ext.go
+++ b/daemon/monitor_ext.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/pkg/broadcastwriter"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/promise"
-	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/utils"
 	"io"
 	"io/ioutil"
@@ -307,11 +306,11 @@ func (m *externalMonitor) resetContainer() {
 
 func newExecDriver() (execdriver.Driver, error) {
 	sysInitPath := path.Join(dockerRoot, "init", fmt.Sprintf("dockerinit-%s", dockerversion.VERSION))
-	sysInfo := sysinfo.New(false)
+	//sysInfo := sysinfo.New(false)
 
 	// only native driver
 	//ed, err := execdrivers.NewDriver(c.ExecDriver, dockerRoot, sysInitPath, sysInfo)
-	ed, err := execdrivers.NewDriver("native", dockerRoot, sysInitPath, sysInfo)
+	ed, err := execdrivers.NewDriver("native", dockerRoot, sysInitPath, execdriver.NativeExternal, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For external container, monitor have no other active container infomation. So have to read container PID from libcontainer state.json for --net="container:xxx".